### PR TITLE
I think that since more-exclude.json contains SukiSU Ultra, it must also contain ReSukiSU.

### DIFF
--- a/common/rom-fingerprints.txt
+++ b/common/rom-fingerprints.txt
@@ -2,7 +2,6 @@
 # Any property whose name contains these substrings gets binary-patched
 # Source: sensitive-props-crontabs propscleaner.sh (silvzr/sensitive-props-crontabs)
 LSPosed
-marketname
 custom.device
 modversion
 lineage

--- a/install_func.sh
+++ b/install_func.sh
@@ -136,6 +136,7 @@ io.github.huskydg.magisk
 me.weishu.kernelsu
 com.rifsxd.ksunext
 com.sukisu.ultra
+com.resukisu.resukisu
 me.bmax.apatch
 me.garfieldhan.apatch.next
 com.android.patch

--- a/more-exclude.json
+++ b/more-exclude.json
@@ -29,6 +29,10 @@
                     "package-name": "com.sukisu.ultra"
                 },
                 {
+                    "name": "ReSukiSU",
+                    "package-name": "com.resukisu.resukisu"
+                },
+                {
                     "name": "Apatch",
                     "package-name": "me.bmax.apatch"
                 },


### PR DESCRIPTION
I think that since more-exclude.json contains SukiSU Ultra, it must also contain ReSukiSU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added ReSukiSU to the app exclusion lists to improve filtering of non-target applications.
  * Removed the "marketname" entry from the ROM fingerprint list to refine fingerprint matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->